### PR TITLE
Fix ripple and restore tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,22 +257,6 @@
       content: attr(data-placeholder);
       color: #aaa;
     }
-    .link-preview {
-      border: 1px solid #ccc;
-      border-radius: 8px;
-      padding: 0.5em;
-      display: flex;
-      gap: 0.5em;
-      align-items: center;
-      margin: 0.5em 0;
-      max-width: 400px;
-    }
-    .link-preview img {
-      width: 40px;
-      height: 40px;
-      object-fit: cover;
-      border-radius: 4px;
-    }
     body.layout-blog #editor {
       max-width: 40em;
       margin: 0 auto;
@@ -292,16 +276,20 @@
       position: fixed;
       pointer-events: none;
       border-radius: 50%;
-      background: rgba(0,0,0,0.2);
+      background: rgba(0,0,0,0.4);
       width: 0;
       height: 0;
       opacity: 0;
       transform: translate(-50%, -50%);
       z-index: 10004;
     }
+    body[data-theme="dark"] #caretRipple,
+    body[data-theme="night"] #caretRipple {
+      background: rgba(255,255,255,0.5);
+    }
     @keyframes ripple {
-      from { width:0; height:0; opacity:0.4; }
-      to { width:30px; height:30px; opacity:0; }
+      from { width:0; height:0; opacity:0.6; }
+      to { width:40px; height:40px; opacity:0; }
     }
     .ripple-animate {
       animation: ripple 0.8s ease-out;
@@ -386,7 +374,6 @@
     editor.innerHTML = localStorage.getItem('omi-content') || '';
     editor.querySelectorAll('img.resizable').forEach(makeImageResizable);
     autoLink(editor);
-    editor.querySelectorAll('a').forEach(createLinkPreview);
     const savedTheme = localStorage.getItem('omi-theme') || 'light';
     document.body.setAttribute('data-theme', savedTheme);
 
@@ -491,7 +478,6 @@
               a.target = '_blank';
               a.setAttribute('spellcheck', 'false');
               frag.appendChild(a);
-              createLinkPreview(a);
               lastIndex = offset + url.length;
             });
             if (lastIndex < text.length) {
@@ -511,29 +497,6 @@
       container.querySelectorAll('a').forEach(a => a.setAttribute('spellcheck', 'false'));
     }
 
-    function createLinkPreview(anchor) {
-      if (anchor.nextSibling && anchor.nextSibling.classList && anchor.nextSibling.classList.contains('link-preview')) return;
-      const url = anchor.href;
-      fetch('https://noembed.com/embed?url=' + encodeURIComponent(url))
-        .then(r => r.json())
-        .then(data => {
-          const preview = document.createElement('div');
-          preview.className = 'link-preview';
-          if (data.thumbnail_url) {
-            const img = document.createElement('img');
-            img.src = data.thumbnail_url;
-            preview.appendChild(img);
-          }
-          const div = document.createElement('div');
-          div.className = 'lp-content';
-          div.innerHTML = `<strong>${data.title || url}</strong>`;
-          if (data.provider_name) div.innerHTML += `<br><em>${data.provider_name}</em>`;
-          preview.appendChild(div);
-          anchor.parentNode.insertBefore(preview, anchor.nextSibling);
-          localStorage.setItem('omi-content', editor.innerHTML);
-        })
-        .catch(()=>{});
-    }
 
     // Inline Markdown support: **bold** and *italic*
     function autoMarkdown(container) {
@@ -1577,8 +1540,10 @@
       helpModal.style.display = 'block';
     });
   </script>
-  
 
-  
+  <script>window.SOLA_SITE_ID = "12u";</script>
+  <script src="https://sola-three.vercel.app/api/sola.js" defer></script>
+
 </body>
-</html> 
+</html>
+


### PR DESCRIPTION
## Summary
- restore the SOLA tracking script
- brighten and enlarge the caret ripple for all themes
- drop link preview injection so only hover tooltip remains

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6840c0dbb9fc8321a778439d9fb5b349